### PR TITLE
Add plist encode functionality

### DIFF
--- a/lib/binary.ex
+++ b/lib/binary.ex
@@ -75,27 +75,13 @@ defmodule Pealist.Binary do
     |> Enum.into(%{})
   end
 
-  defp format_date_time({{year, month, day}, {hour, minute, second}}) do
-    :io_lib.format("~4..0B-~2..0B-~2..0B ~2..0B:~2..0B:~2..0B +0000", [
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second
-    ])
-    |> List.flatten()
-    |> to_string
-  end
-
   defp read_date(handle, length) do
     bytes = 1 <<< length
     <<seconds::float-size(bytes)-unit(8)>> = IO.binread(handle, bytes)
 
     apple_epoch = :calendar.datetime_to_gregorian_seconds({{2001, 1, 1}, {0, 0, 0}})
 
-    :calendar.gregorian_seconds_to_datetime(round(apple_epoch + seconds))
-    |> format_date_time
+    DateTime.from_gregorian_seconds(round(apple_epoch + seconds))
   end
 
   defp read_float(handle, length) do

--- a/lib/plist.ex
+++ b/lib/plist.ex
@@ -24,4 +24,12 @@ defmodule Pealist do
   def parse(data) do
     decode(data)
   end
+
+  @doc """
+  Encode the data provided as an XML format plist.
+  """
+  @spec encode(term()) :: String.t()
+  def encode(data) do
+    Pealist.XML.encode(data)
+  end
 end

--- a/lib/xml.ex
+++ b/lib/xml.ex
@@ -30,6 +30,15 @@ defmodule Pealist.XML do
     parse_value(root)
   end
 
+  def encode(term) do
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    #{encode_plist_data(term, 0)}</plist>
+    """
+  end
+
   defp parse_value(element_node() = element) do
     parse_value(element_node(element, :name), element_node(element, :content))
   end
@@ -39,7 +48,9 @@ defmodule Pealist.XML do
   end
 
   defp parse_value(:date, nodes) do
-    parse_value(:string, nodes)
+    str = parse_value(:string, nodes)
+    {:ok, dt, _} = DateTime.from_iso8601(str)
+    dt
   end
 
   defp parse_value(:data, nodes) do
@@ -107,4 +118,75 @@ defmodule Pealist.XML do
 
   defp empty?({:xmlText, _, _, [], ~c" ", :text}), do: true
   defp empty?(_), do: false
+
+  defp encode_plist_data(%NaiveDateTime{} = dt, level) do
+    dt
+    |> DateTime.from_naive!("Etc/UTC")
+    |> encode_plist_data(level)
+  end
+
+  defp encode_plist_data(%DateTime{time_zone: "Etc/UTC"} = dt, level) do
+    indent(["<date>", DateTime.to_iso8601(dt), "</date>\n"], level)
+  end
+
+  defp encode_plist_data(%DateTime{} = dt, _level) do
+    raise "Unable to encode DateTime #{dt}, please use Etc/UTC timezone"
+  end
+
+  defp encode_plist_data(val, level) when is_map(val) do
+    [
+      indent("<dict>\n", level),
+      val
+      |> Enum.sort_by(fn {k, _v} -> k end)
+      |> Enum.map(fn {k, v} ->
+        [
+          indent(["<key>", xml_escape(k), "</key>\n"], level + 1),
+          encode_plist_data(v, level + 1)
+        ]
+      end),
+      indent("</dict>\n", level)
+    ]
+  end
+
+  defp encode_plist_data(array, level) when is_list(array) do
+    [
+      indent("<array>\n", level),
+      Enum.map(array, &encode_plist_data(&1, level + 1)),
+      indent("</array>\n", level)
+    ]
+  end
+
+  defp encode_plist_data(true, level), do: indent("<true/>\n", level)
+  defp encode_plist_data(false, level), do: indent("<false/>\n", level)
+
+  defp encode_plist_data(int, level) when is_integer(int) do
+    indent(["<integer>", to_string(int), "</integer>\n"], level)
+  end
+
+  defp encode_plist_data(real, level) when is_float(real) do
+    indent(["<real>", to_string(real), "</real>\n"], level)
+  end
+
+  defp encode_plist_data(str, level) when is_binary(str) do
+    if String.printable?(str) do
+      indent(["<string>", xml_escape(str), "</string>\n"], level)
+    else
+      indent(["<data>", Base.encode64(str), "</data>\n"], level)
+    end
+  end
+
+  defp indent(str, level) when is_binary(str), do: indent([str], level)
+
+  defp indent(io_list, level) when is_list(io_list) do
+    [String.duplicate("  ", level) | io_list]
+  end
+
+  defp xml_escape(str) do
+    str
+    |> String.replace("&", "&amp;")
+    |> String.replace(~s("), "&quot;")
+    |> String.replace("'", "&apos;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+  end
 end

--- a/test/fixtures/xml.plist
+++ b/test/fixtures/xml.plist
@@ -2,38 +2,38 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Array</key>
-	<array>
-		<string>A</string>
-		<string>B</string>
-		<string>C</string>
-	</array>
-	<key>Date</key>
-	<date>2015-11-17T14:00:59Z</date>
-	<key>Number</key>
-	<integer>1234</integer>
-	<key>Float</key>
-	<real>1234.1234</real>
-	<key>String</key>
-	<string>foobar</string>
-	<key>True</key>
-	<true/>
-	<key>False</key>
-	<false/>
-	<key>Base64</key>
-	<data>AAECAwQFBgcICQo=</data>
-	<key>EntityEncoded</key>
-	<string>Foo &amp; Bar</string>
-	<key>UnicσdeKey</key>
-	<string>foobar</string>
-	<key>UnicodeValue</key>
-	<string>© 2008 – 2016</string>
-	<key>SomeUID</key>
-	<dict>
-		<key>CF$UID</key>
-		<integer>40</integer>
-	</dict>
   <key></key>
   <string></string>
+  <key>Array</key>
+  <array>
+    <string>A</string>
+    <string>B</string>
+    <string>C</string>
+  </array>
+  <key>Base64</key>
+  <data>AAECAwQFBgcICQo=</data>
+  <key>Date</key>
+  <date>2015-11-17T14:00:59Z</date>
+  <key>EntityEncoded</key>
+  <string>Foo &amp; Bar</string>
+  <key>False</key>
+  <false/>
+  <key>Float</key>
+  <real>1234.1234</real>
+  <key>Number</key>
+  <integer>1234</integer>
+  <key>SomeUID</key>
+  <dict>
+    <key>CF$UID</key>
+    <integer>40</integer>
+  </dict>
+  <key>String</key>
+  <string>foobar</string>
+  <key>True</key>
+  <true/>
+  <key>UnicodeValue</key>
+  <string>© 2008 – 2016</string>
+  <key>UnicσdeKey</key>
+  <string>foobar</string>
 </dict>
 </plist>

--- a/test/plist_test.exs
+++ b/test/plist_test.exs
@@ -8,7 +8,7 @@ defmodule PlistTest do
     assert Map.get(plist, "String") == "foobar"
     assert Map.get(plist, "Number") == 1234
     assert Map.get(plist, "Array") == ["A", "B", "C"]
-    assert Map.get(plist, "Date") == "2015-11-17 14:00:59 +0000"
+    assert Map.get(plist, "Date") == ~U[2015-11-17T14:00:59Z]
     assert Map.get(plist, "True") == true
     assert Map.get(plist, "SomeUID")["CF$UID"] == 40
     assert Map.get(plist, "") == ""
@@ -21,7 +21,7 @@ defmodule PlistTest do
     assert Map.get(plist, "Number") == 1234
     assert Map.get(plist, "Float") == 1234.1234
     assert Map.get(plist, "Array") == ["A", "B", "C"]
-    assert Map.get(plist, "Date") == "2015-11-17T14:00:59Z"
+    assert Map.get(plist, "Date") == ~U[2015-11-17T14:00:59Z]
     assert Map.get(plist, "True") == true
     assert Map.get(plist, "False") == false
     assert Map.get(plist, "Base64") == <<0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10>>
@@ -30,6 +30,18 @@ defmodule PlistTest do
     assert Map.get(plist, "UnicodeValue") == "© 2008 – 2016"
     assert Map.get(plist, "SomeUID")["CF$UID"] == 40
     assert Map.get(plist, "") == ""
+  end
+
+  test "roundtrip (xml)" do
+    original_xml =
+      [File.cwd!(), "test", "fixtures", "xml.plist"]
+      |> Path.join()
+      |> File.read!()
+
+    plist = Pealist.decode(original_xml)
+    encoded_xml = Pealist.encode(plist)
+
+    assert encoded_xml == original_xml
   end
 
   defp parse_fixture(filename) do


### PR DESCRIPTION
Several supporting changes here besides adding a way to encode to plist:
- dates are now parsed into DateTime structs (this is needed so we can distinguish them from strings when encoding)
- the XML test file has been reformatted to the same format Apples plist utility uses (sorted keys, two spaces for indent)

AFAICT, plist dates are always UTC encoded so we enforce the same when encoding.